### PR TITLE
참조 문자 제거 및 php 기본 오브젝트 생성

### DIFF
--- a/textmessage.admin.controller.php
+++ b/textmessage.admin.controller.php
@@ -18,7 +18,6 @@ class textmessageAdminController extends textmessage
 	 **/
 	function procTextmessageAdminInsertConfig() 
 	{
-		$oTextmessageModel = &getModel('textmessage');
 		$args = Context::gets('api_key', 'api_secret', 'callback_url', 'encode_utf16');
 
 		// save module configuration.
@@ -38,7 +37,7 @@ class textmessageAdminController extends textmessage
 		$target_message_ids = Context::get('cart');
 		if(!$target_message_ids) return new Object(-1, 'msg_invalid_request');
 
-		$oTextmessageController = &getController('textmessage');
+		$oTextmessageController = getController('textmessage');
 		foreach($target_message_ids as $id => $val)
 		{
 			$output = $oTextmessageController->cancelMessage($val);
@@ -59,7 +58,7 @@ class textmessageAdminController extends textmessage
 		if(!$target_group_ids) return new Object(-1, 'msg_invalid_request');
 
 		$group_ids = explode(',', $target_group_ids);
-		$oTextmessageController = &getController('textmessage');
+		$oTextmessageController = getController('textmessage');
 
 		$output = $oTextmessageController->cancelGroupMessages($group_ids);
 		if(!$output->toBool()) return $output;

--- a/textmessage.admin.view.php
+++ b/textmessage.admin.view.php
@@ -25,7 +25,7 @@ class textmessageAdminView extends textmessage
 	 **/
 	function dispTextmessageAdminIndex() 
 	{
-		$oTextmessageModel = &getModel('textmessage');
+		$oTextmessageModel = getModel('textmessage');
 		$config = $oTextmessageModel->getConfig();
 		if (!$config) Context::set('isSetupCompleted', false);
 		else Context::set('isSetupCompleted', true);
@@ -54,7 +54,7 @@ class textmessageAdminView extends textmessage
 
 				foreach($item as $key => $val) 
 				{
-					$obj = null;
+					$obj = new stdClass();
 					$obj->title = $val->body;
 					$obj->date = $val->attrs->date;
 					$obj->url = $val->attrs->url;
@@ -74,7 +74,7 @@ class textmessageAdminView extends textmessage
 	 */
 	function dispTextmessageAdminConfig() 
 	{
-		$oTextmessageModel = &getModel('textmessage');
+		$oTextmessageModel = getModel('textmessage');
 		$config = $oTextmessageModel->getConfig();
 
 		$callback_url = Context::getDefaultUrl();
@@ -93,7 +93,7 @@ class textmessageAdminView extends textmessage
 	//발송내역 페이지 
 	function dispTextmessageAdminUsageStatement() 
 	{
-		$oTextmessageModel = &getModel('textmessage');
+		$oTextmessageModel = getModel('textmessage');
 		$config = $oTextmessageModel->getModuleConfig();
 		$sms = $oTextmessageModel->getCoolSMS();
 
@@ -102,6 +102,7 @@ class textmessageAdminView extends textmessage
 		$msg_type = Context::get('msg_type');
 		$rcpt_no = Context::get('rcpt_no');
 		if(!$count) $count = 20;
+		$options = new stdClass();
 		if($msg_type != 'all') $options->type = $msg_type;
 		if(is_numeric($search_code))
 			$options->s_resultcode = $search_code;

--- a/textmessage.controller.php
+++ b/textmessage.controller.php
@@ -27,7 +27,7 @@ class textmessageController extends textmessage
 	 **/
 	function sendMessage($args, $basecamp=FALSE) 
 	{
-		$oTextmessageModel = &getModel('textmessage');
+		$oTextmessageModel = getModel('textmessage');
 		$sms = &$oTextmessageModel->getCoolSMS($basecamp);
 		$options = new stdClass();
 		if($oTextmessageModel->getSlnRegKey() && !$args->srk)
@@ -89,7 +89,7 @@ class textmessageController extends textmessage
 	 */
 	function cancelMessage($msgid, $basecamp=FALSE)
 	{
-		$oTextmessageModel = &getModel('textmessage');
+		$oTextmessageModel = getModel('textmessage');
 		$sms = &$oTextmessageModel->getCoolSMS($basecamp);
 		$options = new stdClass();
 		$options->mid = $msgid;
@@ -105,7 +105,7 @@ class textmessageController extends textmessage
 	 **/
 	function cancelGroupMessages($grpid, $basecamp=FALSE)
 	{
-		$oTextmessageModel = &getModel('textmessage');
+		$oTextmessageModel = getModel('textmessage');
 		$sms = &$oTextmessageModel->getCoolSMS($basecamp);
 		$options = new stdClass();
 		$options->gid = $grpid;

--- a/textmessage.model.php
+++ b/textmessage.model.php
@@ -17,11 +17,11 @@ class textmessageModel extends textmessage
 	{
 		if (!$GLOBALS['__textmessage_config__']) 
 		{
-			$oModuleModel = &getModel('module');
+			$oModuleModel = getModel('module');
 			$config = $oModuleModel->getModuleConfig('textmessage');
 
 			// get logged_info
-			$oMemberModel = &getModel('member');
+			$oMemberModel = getModel('member');
 			$logged_info = Context::get('logged_info');
 			// 회원정보 보기 페이지에서 $logged_info->password를 unset시키기 때문에 새로 가져와야 한다
 			if(!$logged_info->password) $logged_info = $oMemberModel->getMemberInfoByMemberSrl($logged_info->member_srl);


### PR DESCRIPTION
php5.2 부터는 참조 문자가 필요없어졌습니다
(ex, `&getModel()`-> `getModel()`)

php5.1 이하을 사용하며 XE1.7이상 사용하는유저는 그래도 없을테니.. 이렇게 코드를 짜는게 좋을것 같아요 :) 
